### PR TITLE
Fixing of kernel build process and adding of note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Build VyOS 1.4 image on an x86 linux host using qemu-user-static and docker/podm
 
    The required kernel version information by VyOS is [here](https://github.com/vyos/vyos-build/blob/current/data/defaults.toml) and the provided kernel version information for Raspberry Pi is [here](https://github.com/raspberrypi/linux/blob/rpi-5.15.y/Makefile).
    
-   If the version of the kernel you need is different from the kernel provided for pi, you will need to prepare the kernel by other means instead of using the make command below.
+   If the version of the kernel you need is different from the kernel provided for pi, you will need to prepare the kernel by other means instead of using the command below.
 
    ```
    sudo docker run --rm -it --platform linux/arm64 --privileged -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static -v "$(shell pwd)":/vyos -v /dev:/dev --sysctl net.ipv6.conf.lo.disable_ipv6=0 localhost/vyos/vyos-build:current-arm64 /bin/bash -c 'cd /vyos; /bin/bash -x build-pi-kernel.sh'

--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ Build VyOS 1.4 image on an x86 linux host using qemu-user-static and docker/podm
    ```
 
  * Build a Pi kernel:
-   You only have to build the kernel the first time.
+
+   You must build the kernel the first time and when the kernel is upgraded.
+
+   The required kernel version information by VyOS is [here](https://github.com/vyos/vyos-build/blob/current/data/defaults.toml) and the provided kernel version information for Raspberry Pi is [here](https://github.com/raspberrypi/linux/blob/rpi-5.15.y/Makefile).
+   
+   If the version of the kernel you need is different from the kernel provided for pi, you will need to prepare the kernel by other means instead of using the make command below.
 
    ```
    sudo docker run --rm -it --platform linux/arm64 --privileged -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static -v "$(shell pwd)":/vyos -v /dev:/dev --sysctl net.ipv6.conf.lo.disable_ipv6=0 localhost/vyos/vyos-build:current-arm64 /bin/bash -c 'cd /vyos; /bin/bash -x build-pi-kernel.sh'

--- a/build-image.sh
+++ b/build-image.sh
@@ -21,7 +21,10 @@ for a in $(find build -type f -name "*.deb" | grep -v -e "-dbgsym_" -e "libnetfi
 done
 
 # Patch to build-vyos-image script
-#patch -t -u vyos-build/scripts/build-vyos-image < patches/0001_build-vyos-image.patch
+patch -t -u vyos-build/scripts/build-vyos-image < patches/0001_build-vyos-image.patch
+
+# Build to default.toml
+patch -t -u vyos-build/data/defaults.toml < patches/0005_defaults.toml.patch
 
 # Build to arm64.toml
 patch -t -u vyos-build/data/architectures/arm64.toml < patches/0002_arm64.toml.patch

--- a/build-image.sh
+++ b/build-image.sh
@@ -21,7 +21,7 @@ for a in $(find build -type f -name "*.deb" | grep -v -e "-dbgsym_" -e "libnetfi
 done
 
 # Patch to build-vyos-image script
-patch -t -u vyos-build/scripts/build-vyos-image < patches/0001_build-vyos-image.patch
+#patch -t -u vyos-build/scripts/build-vyos-image < patches/0001_build-vyos-image.patch
 
 # Build to arm64.toml
 patch -t -u vyos-build/data/architectures/arm64.toml < patches/0002_arm64.toml.patch

--- a/build-image.sh
+++ b/build-image.sh
@@ -23,10 +23,10 @@ done
 # Patch to build-vyos-image script
 patch -t -u vyos-build/scripts/build-vyos-image < patches/0001_build-vyos-image.patch
 
-# Build to default.toml
+# Patch to default.toml
 patch -t -u vyos-build/data/defaults.toml < patches/0005_defaults.toml.patch
 
-# Build to arm64.toml
+# Patch to arm64.toml
 patch -t -u vyos-build/data/architectures/arm64.toml < patches/0002_arm64.toml.patch
 
 cd vyos-build

--- a/build-pi-kernel.sh
+++ b/build-pi-kernel.sh
@@ -10,7 +10,7 @@ git clone http://github.com/vyos/vyos-build vyos-build
 #patch -t -u vyos-build/packages/linux-kernel/build-linux-firmware.sh < patches/0000_build-linux-firmware.sh.patch
 
 # Patch to vyos_defconfig
-patch -t -u vyos-build/packages/linux-kernel/arch/arm64/configs/vyos_defconfig < patches/0004_vyos_defconfig.patch
+patch -t -u vyos-build/packages/linux-kernel/arch/arm64/configs/vyos_defconfig < patches/0003_vyos_defconfig.patch
 
 cd vyos-build/packages/linux-kernel/
 

--- a/build-pi-kernel.sh
+++ b/build-pi-kernel.sh
@@ -6,8 +6,11 @@ ROOTDIR=$(pwd)
 rm -rf vyos-build
 git clone http://github.com/vyos/vyos-build vyos-build
 
-echo "Patch to build-linux-firmware.sh"
-patch -t -u vyos-build/packages/linux-kernel/build-linux-firmware.sh < patches/0000_build-linux-firmware.sh.patch
+# Patch to build-linux-firmware.sh
+#patch -t -u vyos-build/packages/linux-kernel/build-linux-firmware.sh < patches/0000_build-linux-firmware.sh.patch
+
+# Patch to vyos_defconfig
+patch -t -u vyos-build/packages/linux-kernel/arch/arm64/configs/vyos_defconfig < patches/0004_vyos_defconfig.patch
 
 cd vyos-build/packages/linux-kernel/
 

--- a/build-pi-kernel.sh
+++ b/build-pi-kernel.sh
@@ -22,3 +22,5 @@ git clone https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmwar
 git clone https://github.com/accel-ppp/accel-ppp.git
 ./build-accel-ppp.sh
 
+cd ${ROOTDIR}
+find vyos-build/packages/linux-kernel/ -type f | grep '\.deb$' | xargs -I {} cp {} build/

--- a/build-pi-kernel.sh
+++ b/build-pi-kernel.sh
@@ -7,10 +7,13 @@ rm -rf vyos-build
 git clone http://github.com/vyos/vyos-build vyos-build
 
 # Patch to build-linux-firmware.sh
-#patch -t -u vyos-build/packages/linux-kernel/build-linux-firmware.sh < patches/0000_build-linux-firmware.sh.patch
+patch -t -u vyos-build/packages/linux-kernel/build-linux-firmware.sh < patches/0000_build-linux-firmware.sh.patch
 
 # Patch to vyos_defconfig
-patch -t -u vyos-build/packages/linux-kernel/arch/arm64/configs/vyos_defconfig < patches/0003_vyos_defconfig.patch
+#patch -t -u vyos-build/packages/linux-kernel/arch/arm64/configs/vyos_defconfig < patches/0003_vyos_defconfig.patch
+
+# Patch to build-kernel.sh
+patch -t -u vyos-build/packages/linux-kernel/build-kernel.sh < patches/0004_build-kernel.sh.patch
 
 cd vyos-build/packages/linux-kernel/
 
@@ -23,4 +26,5 @@ git clone https://github.com/accel-ppp/accel-ppp.git
 ./build-accel-ppp.sh
 
 cd ${ROOTDIR}
+mkdir -p build
 find vyos-build/packages/linux-kernel/ -type f | grep '\.deb$' | xargs -I {} cp {} build/

--- a/patches/0000_build-linux-firmware.sh.patch
+++ b/patches/0000_build-linux-firmware.sh.patch
@@ -1,11 +1,11 @@
---- a/vyos-build/packages/linux-kernel/build-linux-firmware.sh	2022-12-31 20:18:03.049039644 +0900
-+++ b/vyos-build/packages/linux-kernel/build-linux-firmware.sh	2022-12-31 20:20:28.169952304 +0900
+--- a/vyos-build/packages/linux-kernel/build-linux-firmware.sh
++++ b/vyos-build/packages/linux-kernel/build-linux-firmware.sh
 @@ -26,7 +26,7 @@
  
  result=()
  # Retrieve firmware blobs from source files
 -FW_FILES=$(find ${LINUX_SRC}/debian/linux-image/lib/modules/${KERNEL_VERSION}${KERNEL_SUFFIX}/kernel/drivers/net -name *.ko | xargs modinfo | grep "^firmware:" | awk '{print $2}')
-+FW_FILES=$(find ${LINUX_SRC}/debian/linux-image/lib/modules/${KERNEL_VERSION}-v8${KERNEL_SUFFIX}/kernel/drivers/net -name *.ko | xargs modinfo | grep "^firmware:" | awk '{print $2}')
++FW_FILES=$(find ${LINUX_SRC}/debian/linux-image/lib/modules/${KERNEL_RELEASE}${KERNEL_SUFFIX}/kernel/drivers/net -name *.ko | xargs modinfo | grep "^firmware:" | awk '{print $2}')
  
  # Debian package will use the descriptive Git commit as version
  GIT_COMMIT=$(cd ${CWD}/${LINUX_FIRMWARE}; git describe --always)

--- a/patches/0001_build-vyos-image.patch
+++ b/patches/0001_build-vyos-image.patch
@@ -1,11 +1,11 @@
---- a/vyos-build/scripts/build-vyos-image	2022-12-31 21:23:16.613516733 +0900
-+++ b/vyos-build/scripts/build-vyos-image	2022-12-31 21:23:56.269760316 +0900
+--- a/vyos-build/scripts/build-vyos-image
++++ b/vyos-build/scripts/build-vyos-image
 @@ -424,7 +424,7 @@
              --bootappend-live "boot=live components hostname=vyos username=live nopersistence noautologin nonetworking union=overlay console=ttyS0,115200 console=tty0 net.ifnames=0 biosdevname=0" \
              --bootappend-live-failsafe "live components memtest noapic noapm nodma nomce nolapic nomodeset nosmp nosplash vga=normal console=ttyS0,115200 console=tty0 net.ifnames=0 biosdevname=0" \
              --linux-flavours {{kernel_flavor}} \
 -            --linux-packages linux-image-{{kernel_version}} \
-+            --linux-packages linux-image-{{kernel_version}}-v8 \
++            --linux-packages linux-image-{{kernel_version}}{{kernel_localversion}} \
              --bootloader {{ bootloaders }} \
              --binary-images iso-hybrid \
              --checksums 'sha256 md5' \

--- a/patches/0002_arm64.toml.patch
+++ b/patches/0002_arm64.toml.patch
@@ -1,10 +1,11 @@
---- a/vyos-build/data/architectures/arm64.toml	2022-12-31 21:26:39.310760935 +0900
-+++ b/vyos-build/data/architectures/arm64.toml	2022-12-31 21:27:31.443059203 +0900
-@@ -1,3 +1,9 @@
+--- a/vyos-build/data/architectures/arm64.toml
++++ b/vyos-build/data/architectures/arm64.toml
+@@ -1,3 +1,10 @@
 -# Packages included in ARM64 images by default
 -packages = ["grub-efi-arm"]
 -bootloaders = "grub-efi"
 \ No newline at end of file
++kernel_localversion = "-v8"
 +kernel_flavor = "arm64-vyos"
 +
 +# Packages added to images for ARM64 by default

--- a/patches/0002_arm64.toml.patch
+++ b/patches/0002_arm64.toml.patch
@@ -7,7 +7,7 @@
 \ No newline at end of file
 +kernel_flavor = "arm64-vyos"
 +
-+# Packages added to images for x86 by default
++# Packages added to images for ARM64 by default
 +packages = [
 +  "vyos-linux-firmware",
 +  "telegraf",

--- a/patches/0003_vyos_defconfig.patch
+++ b/patches/0003_vyos_defconfig.patch
@@ -1,5 +1,5 @@
---- a/vyos-build/packages/linux-kernel/arch/arm64/configs/vyos_defconfig	2023-01-05 19:47:26.998132299 +0900
-+++ b/vyos-build/packages/linux-kernel/arch/arm64/configs/vyos_defconfig	2023-01-05 19:48:08.626381978 +0900
+--- a/vyos-build/packages/linux-kernel/arch/arm64/configs/vyos_defconfig
++++ b/vyos-build/packages/linux-kernel/arch/arm64/configs/vyos_defconfig
 @@ -21,7 +21,7 @@
  #
  CONFIG_INIT_ENV_ARG_LIMIT=32

--- a/patches/0003_vyos_defconfig.patch
+++ b/patches/0003_vyos_defconfig.patch
@@ -1,0 +1,11 @@
+--- a/vyos-build/packages/linux-kernel/arch/arm64/configs/vyos_defconfig	2023-01-05 19:47:26.998132299 +0900
++++ b/vyos-build/packages/linux-kernel/arch/arm64/configs/vyos_defconfig	2023-01-05 19:48:08.626381978 +0900
+@@ -21,7 +21,7 @@
+ #
+ CONFIG_INIT_ENV_ARG_LIMIT=32
+ # CONFIG_COMPILE_TEST is not set
+-CONFIG_LOCALVERSION="-v8"
++CONFIG_LOCALVERSION=""
+ # CONFIG_LOCALVERSION_AUTO is not set
+ CONFIG_BUILD_SALT=""
+ CONFIG_DEFAULT_INIT=""

--- a/patches/0004_build-kernel.sh.patch
+++ b/patches/0004_build-kernel.sh.patch
@@ -1,0 +1,12 @@
+--- a/vyos-build/packages/linux-kernel/build-kernel.sh
++++ b/vyos-build/packages/linux-kernel/build-kernel.sh
+@@ -52,3 +52,9 @@
+         ln -sf linux-kernel/$package ..
+     done
+ fi
++
++cd ${KERNEL_SRC}
++echo "I: Add Kernel variable to Generated environment file"
++cat << EOF >>${CWD}/kernel-vars
++export KERNEL_RELEASE=$(make kernelrelease)
++EOF

--- a/patches/0005_defaults.toml.patch
+++ b/patches/0005_defaults.toml.patch
@@ -1,0 +1,4 @@
+--- a/vyos-build/data/defaults.toml
++++ b/vyos-build/data/defaults.toml
+@@ -15,0 +16 @@
++kernel_localversion = ""


### PR DESCRIPTION
Changed from adding -v8 in the process after building the kernel to not adding -v8 when building the kernel.
Added note about the case where the kernel version required by vyos is different from the version of the kernel for pi.