### PR TITLE
Fix toml patch

### DIFF
--- a/patches/0002_arm64.toml.patch
+++ b/patches/0002_arm64.toml.patch
@@ -1,18 +1,23 @@
---- a/vyos-build/data/architectures/arm64.toml
-+++ b/vyos-build/data/architectures/arm64.toml
-@@ -1,3 +1,14 @@
-+additional_repositories = [
+diff --git a/data/architectures/arm64.toml b/data/architectures/arm64.toml
+index e48d9f4..993ac3f 100644
+--- a/data/architectures/arm64.toml
++++ b/data/architectures/arm64.toml
+@@ -1,9 +1,14 @@
+ additional_repositories = [
+-  "deb [arch=arm64] https://repo.saltproject.io/py3/debian/11/arm64/3004 bullseye main"
 +  "deb [arch=arm64] https://repo.saltproject.io/py3/debian/11/arm64/3004 bullseye main",
 +  "deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-48 main"
-+]
-+
-+kernel_flavor = "v8-arm64-vyos"
-+
+ ]
+ 
+ kernel_flavor = "v8-arm64-vyos"
+ 
  # Packages included in ARM64 images by default
--packages = ["grub-efi-arm"]
+-packages = ["grub-efi-arm64"]
+-bootloaders = "grub-efi"
+\ No newline at end of file
 +packages = [
 +  "vyos-linux-firmware",
 +  "telegraf",
 +  "grub-efi-arm64"
 +]
- bootloaders = "grub-efi"
++bootloaders = "grub-efi"


### PR DESCRIPTION
Fixes build for vyos-build:current when toml patch cannot be applied.