### PR TITLE
Fix toml patch

### DIFF
--- a/patches/0002_arm64.toml.patch
+++ b/patches/0002_arm64.toml.patch
@@ -1,15 +1,16 @@
 --- a/vyos-build/data/architectures/arm64.toml
 +++ b/vyos-build/data/architectures/arm64.toml
-@@ -1,3 +1,14 @@
-+additional_repositories = [
+@@ -1,9 +1,14 @@
+ additional_repositories = [
+-  "deb [arch=arm64] https://repo.saltproject.io/py3/debian/11/arm64/3004 bullseye main"
 +  "deb [arch=arm64] https://repo.saltproject.io/py3/debian/11/arm64/3004 bullseye main",
 +  "deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-48 main"
-+]
-+
-+kernel_flavor = "v8-arm64-vyos"
-+
+ ]
+
+ kernel_flavor = "v8-arm64-vyos"
+
  # Packages included in ARM64 images by default
--packages = ["grub-efi-arm"]
+-packages = ["grub-efi-arm64"]
 +packages = [
 +  "vyos-linux-firmware",
 +  "telegraf",


### PR DESCRIPTION
Fixes toml patch which can not be applied to vyos-build:current branch.